### PR TITLE
Fix failure when using Bouncy Castle as JCE provider.

### DIFF
--- a/src/main/java/org/apache/commons/ssl/KeyStoreBuilder.java
+++ b/src/main/java/org/apache/commons/ssl/KeyStoreBuilder.java
@@ -564,6 +564,13 @@ public class KeyStoreBuilder {
             // swallow it, return null.
             return null;
         }
+        catch (NullPointerException npe) {
+            String msg = npe.getMessage() != null ? npe.getMessage() : "";
+            if (msg.equals("No password supplied for PKCS#12 KeyStore.")) {
+                return null;
+            }
+            throw npe;
+        }
     }
 
     private static X509Certificate[] toChain(Collection certs) {


### PR DESCRIPTION
BC throws a NPE when when trying to open a pkcs12 keystore without
a password which escapes the multiple calls to tryJKS.

Looking at exception message is a bit ugly, but, I suppose for this
old library it is ok.